### PR TITLE
Load windIO file in-memory and unpack

### DIFF
--- a/foxes/input/windio/windio.py
+++ b/foxes/input/windio/windio.py
@@ -11,8 +11,9 @@ from foxes.models.turbine_types import CpCtFromTwo
 import foxes.constants as FC
 import foxes.variables as FV
 
+from windIO.utils.yml_utils import load_yaml
 
-def read_resource(res_yaml, fixed_vars={}, **kwargs):
+def read_resource(res, fixed_vars={}, **kwargs):
     """
     Reads a WindIO energy resource
 
@@ -32,10 +33,6 @@ def read_resource(res_yaml, fixed_vars={}, **kwargs):
         The uniform states
 
     """
-    res_yaml = Path(res_yaml)
-
-    with open(res_yaml, "r") as file:
-        res = yaml.load(file, Loader=yaml.loader.BaseLoader)
     wres = res["wind_resource"]
 
     wd = np.array(wres["wind_direction"], dtype=FC.DTYPE)
@@ -106,7 +103,7 @@ def read_resource(res_yaml, fixed_vars={}, **kwargs):
     return StatesTable(data, output_vars=ovars, fixed_vars=fixed_vars, **kwargs)
 
 
-def read_site(site_yaml, **kwargs):
+def read_site(site, **kwargs):
     """
     Reads a WindIO site
 
@@ -123,20 +120,12 @@ def read_site(site_yaml, **kwargs):
         The states object
 
     """
-    site_yaml = Path(site_yaml)
-
-    with open(site_yaml, "r") as file:
-        site = yaml.load(file, Loader=yaml.loader.BaseLoader)
-
     res_yaml = site["energy_resource"]
-    if res_yaml[0] == ".":
-        res_yaml = (site_yaml.parent / res_yaml).resolve()
     states = read_resource(res_yaml, **kwargs)
 
     return states
 
-
-def read_farm(farm_yaml, mbook=None, layout=-1, turbine_models=[], **kwargs):
+def read_farm(fdict, mbook=None, layout=-1, turbine_models=[], **kwargs):
     """
     Reads a WindIO wind farm
 
@@ -162,10 +151,6 @@ def read_farm(farm_yaml, mbook=None, layout=-1, turbine_models=[], **kwargs):
 
     """
     mbook = ModelBook() if mbook is None else mbook
-    farm_yaml = Path(farm_yaml)
-
-    with open(farm_yaml, "r") as file:
-        fdict = yaml.load(file, Loader=yaml.loader.BaseLoader)
 
     if isinstance(layout, str):
         layout = fdict["layouts"][layout]
@@ -181,19 +166,8 @@ def read_farm(farm_yaml, mbook=None, layout=-1, turbine_models=[], **kwargs):
     ldata["x"] = x
     ldata["y"] = y
 
-    if "turbines" in fdict:
-        turbines_yaml = fdict["turbines"]
-        if turbines_yaml[0] == ".":
-            turbines_yaml = (farm_yaml.parent / turbines_yaml).resolve()
-
-        with open(turbines_yaml, "r") as file:
-            tdict = yaml.load(file, Loader=yaml.loader.BaseLoader)
-
-        pdict = tdict["performance"]
-
-    else:
-        tdict = fdict
-        pdict = fdict
+    tdict = fdict["turbines"]
+    pdict = tdict["performance"]
 
     ct_ws = np.array(pdict["Ct_curve"]["Ct_wind_speeds"], dtype=FC.DTYPE)
     ct_data = pd.DataFrame(index=range(len(ct_ws)))
@@ -209,11 +183,17 @@ def read_farm(farm_yaml, mbook=None, layout=-1, turbine_models=[], **kwargs):
     H = float(tdict["hub_height"])
 
     mbook.turbine_types["windio_turbine"] = CpCtFromTwo(
-        cp_data, ct_data, col_ws_cp_file="ws", col_cp="cp", D=D, H=H
+        cp_data,
+        ct_data,
+        col_ws_cp_file="ws",
+        col_cp="cp",
+        D=D,
+        H=H
     )
 
     models = ["windio_turbine"] + turbine_models
     farm = WindFarm(name=fdict["name"])
+
     add_from_df(farm, ldata, col_x="x", col_y="y", turbine_models=models, **kwargs)
 
     return mbook, farm
@@ -286,19 +266,12 @@ def read_case(case_yaml, site_pars={}, farm_pars={}, ana_pars={}):
     :group: input.windio
 
     """
-    case_yaml = Path(case_yaml)
-
-    with open(case_yaml, "r") as file:
-        case = yaml.load(file, Loader=yaml.loader.BaseLoader)
+    case = load_yaml(case_yaml)
 
     site_yaml = case["site"]
-    if site_yaml[0] == ".":
-        site_yaml = (case_yaml.parent / site_yaml).resolve()
     states = read_site(site_yaml, **site_pars)
 
     farm_yaml = case["wind_farm"]
-    if farm_yaml[0] == ".":
-        farm_yaml = (case_yaml.parent / farm_yaml).resolve()
     mbook, farm = read_farm(farm_yaml, **farm_pars)
 
     attr_dict = case["attributes"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     kaleido
     iwopy>=0.1.4
     pymoo>=0.6
+    windIO>=1.0
 
 [options.extras_require]
 test =


### PR DESCRIPTION
This pull request modified the windIO interface so that it loads the input file once and parses the contents in memory to build up the foxes data. This was discussed in #40.

Currently, the [foxes-windIO interface](https://github.com/FraunhoferIWES/foxes/blob/main/foxes/input/windio/windio.py) loads the windIO file and creates the necessary data via five functions:

```python
def read_resource():
def read_site():
def read_farm():
def read_anlyses():
def read_case():
```
Four of the five contain similar boilerplate code to load and unpack the input file, such as:
```python
res_yaml = Path(res_yaml)
with open(res_yaml, "r") as file:
    res = yaml.load(file, Loader=yaml.loader.BaseLoader)
```

This pull request enables creating inputs by modifying the dictionary that results from the windIO input file rather than creating new input files to represent the data. Additionally, it uses the YAML loader included in windIO allowing foxes to stay in sync with any infrastructure changes added to windIO.

The modified flow is summarized below where the solid line represents a function calling another while the dashed line means the results of one is passed to the next in sequence. The difference from the current flow is what data is being passed between the functions.

```mermaid
flowchart
  A["read_case(case_yaml: str | Path):"]
  AA["windIO.load_yml -> data_dict"]
  B["read_site(site_dict) -> states"]
  C["read_resource(resource_dict)"]
  D["read_farm(farm_dict) -> mbook, farm"]
  E["read_analyses(attr_dict, mbook, farm, states, ...)"]
  A --> AA
  AA -.-> B
  B --> C
  AA -.-> D
  AA -.-> E
  B -.-> E
  D -.-> E
```